### PR TITLE
gh-29 Warn about keyworded formatters on pep3101

### DIFF
--- a/plone/recipe/codeanalysis/pep3101.py
+++ b/plone/recipe/codeanalysis/pep3101.py
@@ -44,7 +44,8 @@ def _code_analysis_pep3101_lines_parser(lines, file_path):
     errors = []
     linenumber = 0
 
-    string_formatters = ('s', 'i', 'p', 'r')
+    # the ( is to catch keyword formatters '%(something)s'
+    string_formatters = ('s', 'i', 'p', 'r', '(')
 
     for line in lines:
         linenumber += 1


### PR DESCRIPTION
Make sure to warn about keyworded arguments in formatting string, i.e.:

```
print '%(key)s: %(value)s' % (key, value)
```
