### PR TITLE
Fix shebang to the standard /usr/bin/env. fix #55.

### DIFF
--- a/plone/recipe/codeanalysis/templates/pre-commit.tmpl
+++ b/plone/recipe/codeanalysis/templates/pre-commit.tmpl
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 bin/code-analysis


### PR DESCRIPTION
Closes #55 
