### PR TITLE
JavaScript Code Style Checker support

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -1,0 +1,22 @@
+{
+  "disallowEmptyBlocks": true,
+  "disallowKeywords": ["with"],
+  "disallowLeftStickedOperators": ["?", "+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
+  "disallowMixedSpacesAndTabs": true,
+  "disallowMultipleLineStrings": true,
+  "disallowRightStickedOperators": ["?", "/", "*", ":", "=", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
+  "disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-", "~"],
+  "disallowSpaceBeforePostfixUnaryOperators": ["++", "--"],
+  "disallowTrailingWhitespace": true,
+  "requireCamelCaseOrUpperCaseIdentifiers": true,
+  "requireLeftStickedOperators": [","],
+  "requireLineFeedAtFileEnd": true,
+  "requireRightStickedOperators": ["!"],
+  "requireSpaceAfterBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!=="],
+  "requireSpaceAfterKeywords": ["if", "else", "for", "while", "do", "switch", "return", "try", "catch"],
+  "requireSpaceBeforeBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!=="],
+  "requireSpacesInFunctionExpression": { "beforeOpeningCurlyBrace": true },
+  "validateIndentation": 2,
+  "validateLineBreaks": "LF",
+  "validateQuoteMarks": "'"
+}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Change history
 1.0b7 (unreleased)
 ------------------
 
+- Add Javascript Code Style Checker ``jscs`` support.
+  [saily]
+
 - Remove hard dependency on i18ndude and zptlint; this will reduce the number
   of Zope/Plone direct dependencies to make life happier to people using
   Pyramid and other web Python-based development frameworks (closes `#53`_).

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -5,3 +5,4 @@ Contributors
 - Gil Forcada
 - Héctor Velarde
 - Ramiro Batista da Luz
+- Daniel Widerin

--- a/README.rst
+++ b/README.rst
@@ -162,6 +162,37 @@ The recipe supports the following options:
     in a file named ``.jshintignore``. See `JSHint documentation`_ for more
     details.
 
+**jscs**
+    If set to True, jscs code analysis is run. Default is ``False``.
+
+    JavaScript Code Style options should be configured using a ``.jscs.json``
+    file. You should align your javascript code to the next generation of
+    Plone's javascript framework Mockup_ and take it's ``.jscs.json`` file
+    which is available here:
+    https://github.com/plone/mockup/blob/master/.jscs.json
+
+    All configuration options are documented on the `jscs website`_.
+
+**jscs-bin**
+    Set the path to a custom version of JSCS, e.g.
+    "/usr/local/bin/jscs".
+
+    If you have Javascript Code Style Checker installed in your system and
+    path, you have nothing to do. To install with Buildout, add the following
+    section to your buildout and set jscs-bin to
+    ``{buildout:bin-directory}/jscs``::
+
+        [jscs]
+        recipe = gp.recipe.node
+        npms = jscs
+        scripts = jscs
+
+**jscs-exclude**
+    Allows you to specify directories which you don't want to be checked.
+    Default is none. Note that these directories have to be given in absolute
+    paths, use ``${buildout:directory}/foo/bar/static/js-3rd-party`` for
+    example.
+
 **csslint**
     If set to True, CSS Lint code analysis is run. Default is ``False``.
 
@@ -291,3 +322,5 @@ Upgrade JSHint to latest version (>= 2.1.6) to fix this issue, e.g.::
 .. _`zptlint`: https://pypi.python.org/pypi/zptlint
 .. _`i18ndude`: https://pypi.python.org/pypi/i18ndude
 .. _`Unit testing framework documentation`: http://docs.python.org/2/library/unittest.html#deprecated-aliases
+.. _`Mockup`: https://github.com/plone/mockup
+.. _`jscs website`: https://www.npmjs.org/package/jscs

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -9,8 +9,8 @@ versions = versions
 
 [node]
 recipe = gp.recipe.node
-npms = csslint jshint
-scripts = csslint jshint
+npms = csslint jshint jscs
+scripts = csslint jshint jscs
 
 [test]
 recipe = zc.recipe.testrunner

--- a/plone/recipe/codeanalysis/__init__.py
+++ b/plone/recipe/codeanalysis/__init__.py
@@ -7,6 +7,7 @@ from plone.recipe.codeanalysis.flake8 import code_analysis_flake8
 from plone.recipe.codeanalysis.i18ndude import code_analysis_find_untranslated
 from plone.recipe.codeanalysis.imports import code_analysis_imports
 from plone.recipe.codeanalysis.jshint import code_analysis_jshint
+from plone.recipe.codeanalysis.jscs import code_analysis_jscs
 from plone.recipe.codeanalysis.pep3101 import code_analysis_pep3101
 from plone.recipe.codeanalysis.python_utf8_header import \
     code_analysis_utf8_header
@@ -54,6 +55,10 @@ class Recipe(object):
         self.options.setdefault('jshint', 'False')
         self.options.setdefault('jshint-bin', 'jshint')
         self.options.setdefault('jshint-exclude', '')
+        # JSCS
+        self.options.setdefault('jscs', 'False')
+        self.options.setdefault('jscs-bin', 'jscs')
+        self.options.setdefault('jscs-exclude', '')
         # CSS Lint
         self.options.setdefault('csslint', 'False')
         self.options.setdefault('csslint-bin', 'csslint')
@@ -148,6 +153,8 @@ class Recipe(object):
             {'suffix': 'flake8', },
             # bin/code-analysis-jshint
             {'suffix': 'jshint', },
+            # bin/code-analysis-jshint
+            {'suffix': 'jscs', },
             # bin/code-analysis-csslint
             {'suffix': 'csslint', },
             # bin/code-analysis-zptlint
@@ -237,6 +244,7 @@ def code_analysis(options):
     checks = [
         ['flake8', code_analysis_flake8],
         ['jshint', code_analysis_jshint],
+        ['jscs', code_analysis_jscs],
         ['csslint', code_analysis_csslint],
         ['zptlint', code_analysis_zptlint],
         ['deprecated-aliases', code_analysis_deprecated_aliases],

--- a/plone/recipe/codeanalysis/jscs.py
+++ b/plone/recipe/codeanalysis/jscs.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+from plone.recipe.codeanalysis.utils import _find_files
+from plone.recipe.codeanalysis.utils import _normalize_boolean
+from plone.recipe.codeanalysis.utils import log
+from plone.recipe.codeanalysis.utils import _read_subprocess_output
+from tempfile import TemporaryFile
+
+import os
+import re
+
+
+def jscs_errors(output, jenkins=False):
+    """Search for error on the output.
+
+    JSCS shows errors only, 2 different output types could occurr:
+    - 1 code style error found.
+    - No code style error found.
+
+    :param output: Output to be checked.
+    :param jenkins: It is true when the jenkins output is turned on.
+
+    """
+    pattern = r'severity="error"' if jenkins else \
+              r'[0-9]+ code style errors? found\.'
+    error = re.compile(pattern)
+    return error.search(output)
+
+
+class CmdError(Exception):
+    pass
+
+
+def run_cmd(options, jenkins):
+    """Run the jscs command using options.
+
+    Run the jscs command using options and return the output.
+
+    :param options: Options received by the code_analysis_jscs funciton.
+    :param jenkins: It is true when the jenkins output is turned on.
+
+    """
+    # cmd is a sequence of program arguments
+    cmd = [options['jscs-bin']]     # , '--reporter=inline', '--no-colors']
+
+    all_files = _find_files(options, '.*\.js').strip().split('\n')
+    exc_files = _find_files({
+        'directory': options['jscs-exclude'],
+    }, '.*\.js').strip().split('\n')
+
+    # Remove excluded files
+    files = set(all_files) - set(exc_files)
+
+    if not files:
+        log('ok')
+        return True
+
+    # put all files in a single line
+    cmd += list(files)
+
+    try:
+        if jenkins:
+            cmd.append('--reporter=checkstyle')
+            output_file_name = os.path.join(options['location'], 'jscs.xml')
+            output_file = open(output_file_name, 'w+')
+        else:
+            output_file = TemporaryFile('w+')
+
+        # Wrapper to subprocess.Popen
+        try:
+            # Return code is not used for jscs.
+            output = _read_subprocess_output(cmd, output_file)[0]
+            return output
+        except OSError:
+            log('skip')
+            message = 'Command: {0}. Outputfile: {1}'.format(cmd, output_file)
+            raise CmdError(message)
+    finally:
+        output_file.close()
+
+
+def code_analysis_jscs(options):
+    log('title', 'JSCS')
+    jenkins = _normalize_boolean(options['jenkins'])
+
+    try:
+        output = run_cmd(options, jenkins)
+    except CmdError:
+        log('skip')
+        return False
+
+    if jscs_errors(output, jenkins):
+        if jenkins:
+            output_file_name = os.path.join(options['location'], 'jscs.xml')
+            log('failure', 'Output file written to %s.' % output_file_name)
+        else:
+            log('failure', output)
+        return False
+    else:
+        log('ok')
+        return True

--- a/plone/recipe/codeanalysis/tests/jscs.rst
+++ b/plone/recipe/codeanalysis/tests/jscs.rst
@@ -1,0 +1,23 @@
+Javascript Code Style Checker Test
+==================================
+
+JSCS code analysis is included by default::
+
+    >>> write('buildout.cfg',
+    ... """
+    ... [buildout]
+    ... parts = code-analysis
+    ...
+    ... [code-analysis]
+    ... recipe = plone.recipe.codeanalysis
+    ... directory = %(directory)s
+    ... jscs = True
+    ... """ % {
+    ...     'directory' : '${buildout:directory}/plone/recipe/codeanalysis',
+    ... })
+    >>> buildout_output_lower = system(buildout).lower()
+
+JSCS code analysis script has been created::
+
+    >>> '/sample-buildout/bin/code-analysis-jscs' in buildout_output_lower
+    True

--- a/plone/recipe/codeanalysis/tests/test_jscs.py
+++ b/plone/recipe/codeanalysis/tests/test_jscs.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+import unittest
+from plone.recipe.codeanalysis.jscs import code_analysis_jscs
+from plone.recipe.codeanalysis.jscs import jscs_errors
+from shutil import rmtree
+from tempfile import mkdtemp
+from os.path import join as path_join
+from os.path import isfile as path_isfile
+
+INCORRECT_FILE = """\
+function a_method(){
+  if(window.location.hash == null) return
+}
+"""
+
+CORRECT_FILE = """\
+function slideJump() {
+  if (window.location.hash === null) {
+    return;
+  }
+}
+"""
+
+XML_EMPTY_OUTPUT = """\
+<?xml version="1.0" encoding="utf-8"?>
+<checkstyle version="4.3">
+    <file name="test.js">
+    </file>
+</checkstyle>"""
+
+XML_OUTPUT = """\
+<?xml version="1.0" encoding="utf-8"?>
+<checkstyle version="4.3">
+    <file name="test.js">
+        <error line="1" column="10" severity="error" message="All identifiers must be camelCase or UPPER_CASE" source="jscs" />
+        <error line="1" column="19" severity="error" message="Missing space before opening curly brace" source="jscs" />
+    </file>
+</checkstyle>"""  # noqa
+
+DEFAULT_OUTPUT = """\
+All identifiers must be camelCase or UPPER_CASE at /tmp/tmp679DaV/incorrect.js :
+     1 |function a_method(){
+-----------------^
+     2 |  if(window.location.hash == null) return
+     3 |}
+
+Missing space before opening curly brace at /tmp/tmp679DaV/incorrect.js :
+     1 |function a_method(){
+--------------------------^
+     2 |  if(window.location.hash == null) return
+     3 |}
+
+
+2 code style errors found.
+"""  # noqa
+
+
+class TestJavascriptCodeStyleChecker(unittest.TestCase):
+
+    def setUp(self):
+        self.options = {
+            'jscs-bin': 'bin/jscs',
+            'jscs-exclude': '',
+            'jenkins': 'False'
+        }
+        self.test_dir = mkdtemp()
+
+    def tearDown(self):
+        rmtree(self.test_dir)
+
+    def test_analysis_should_return_false_when_error_found(self):
+        full_path = path_join(self.test_dir, 'incorrect.js')
+        with file(full_path, 'w') as incorrect_code:
+            incorrect_code.write(INCORRECT_FILE)
+        self.options['directory'] = self.test_dir
+        self.assertFalse(code_analysis_jscs(self.options))
+
+    def test_analysis_should_return_false_when_oserror(self):
+        # The options are fake, so the function should raise an OSError
+        # and return false.
+        self.options['jscs-bin'] = 'FAKE_BIN'
+        self.options['directory'] = 'FAKE_DIR'
+        self.assertFalse(code_analysis_jscs(self.options))
+
+    def test_analysis_should_return_true(self):
+        full_path = path_join(self.test_dir, 'correct.js')
+        with file(full_path, 'w') as correct_code:
+            correct_code.write(CORRECT_FILE)
+        self.options['directory'] = self.test_dir
+        self.assertTrue(code_analysis_jscs(self.options))
+
+    def test_analysis_file_should_exist_when_jenkins_is_true(self):
+        location_tmp_dir = mkdtemp()
+        full_path = path_join(self.test_dir, 'correct.js')
+        with file(full_path, 'w') as correct_code:
+            correct_code.write(CORRECT_FILE)
+        self.options['directory'] = self.test_dir
+        self.options['location'] = location_tmp_dir
+        self.options['jenkins'] = 'True'  # need to activate jenkins.
+        code_analysis_jscs(self.options)
+        file_exist = path_isfile(path_join(location_tmp_dir, 'jscs.xml'))
+        rmtree(location_tmp_dir)
+        self.assertTrue(file_exist)
+
+    def test_jscs_errors_should_return_false_empty_xml_output(self):
+        self.assertFalse(jscs_errors(XML_EMPTY_OUTPUT, True))
+
+    def test_jscs_errors_should_return_true_with_xml_output(self):
+        self.assertTrue(jscs_errors(XML_OUTPUT, True))
+
+    def test_jscs_errors_should_return_true_with_normal_output(self):
+        self.assertTrue(jscs_errors(DEFAULT_OUTPUT, False))
+
+    def test_jscs_errors_should_return_false_empty_normal_output(self):
+        self.assertFalse(jscs_errors('', False))


### PR DESCRIPTION
Add JavaScript Code Style Checker support to p.a.codeanalysis. 
Sorry for not completing the tests, shouldn't be too hard, similar to jshint ones, but just needs to be done. 
