### PR TITLE
fix(utils): Find files but not directories

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Change history
 - Add option to store flake8 output if jenkins is False
   [Michael Davis]
 
+- Fix find_files from utils to find files, not directories
+  [do3cc]
+
 1.0rc1 (2014-06-18)
 -------------------
 

--- a/plone/recipe/codeanalysis/tests/test_utils.py
+++ b/plone/recipe/codeanalysis/tests/test_utils.py
@@ -70,3 +70,19 @@ class TestUtils(unittest.TestCase):
         sorted_output = '\n'.join(sorted(output.splitlines()))
         expect = '\n'.join([x.name for x in temp_files])
         self.assertEqual(expect, sorted_output)
+
+    def test_find_files_not_dirs(self):
+        test_dir = mkdtemp()
+        temp_files = []
+        for n in range(1, 5):
+            temp_file = NamedTemporaryFile(
+                'w+',
+                suffix='.py',
+                prefix='tmp' + str(n),
+                dir=test_dir)
+            temp_files.append(temp_file)
+        mkdtemp(suffix='.py', dir=test_dir)
+        output = find_files({'directory': test_dir}, '.*py')
+        sorted_output = '\n'.join(sorted(output.splitlines()))
+        expect = '\n'.join([x.name for x in temp_files])
+        self.assertEqual(expect, sorted_output)

--- a/plone/recipe/codeanalysis/utils.py
+++ b/plone/recipe/codeanalysis/utils.py
@@ -33,7 +33,7 @@ def normalize_boolean(value):
 
 def find_files(options, regex):
     paths = options['directory'].split('\n')
-    cmd = ['find', '-L'] + paths + ['-regex', regex]
+    cmd = ['find', '-L'] + paths + ['-regex', regex, '-type', 'f']
     process_files = subprocess.Popen(
         cmd,
         stderr=subprocess.STDOUT,


### PR DESCRIPTION
This occured in ploneintranet, where
a directory has a name of something.js
The checker treated it as a file.
