### PR TITLE
Add multiprocessing support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Change history
 2.0.0 (unreleased)
 ------------------
 
+- Added multiprocessing. This will dramatically increase speed on large
+  packages when using pre-commit hooks.
+  [saily]
+
 - Return correct exit codes for console-scripts, fixes #66.
   [saily]
 

--- a/README.rst
+++ b/README.rst
@@ -125,6 +125,12 @@ The recipe supports the following options:
     If set to True, a git pre-commit hook is installed that runs the code
     analysis before each commit. Default is ``True``.
 
+**multiprocessing**
+    If set to ``True``, ``code-analysis`` will fork multiple processes and run
+    all linters in parallel. This will dramatically increase speed on a
+    multi-core system, specially when using ``code-analysis`` as pre-commit
+    hook. Default is ``False``.
+
 **jenkins**
     If set to True, the flake8, jshint and csslint code analysis steps will
     write output files that can be processed by the

--- a/plone/recipe/codeanalysis/__init__.py
+++ b/plone/recipe/codeanalysis/__init__.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+from multiprocessing import Lock
+from multiprocessing import Process
+from multiprocessing import Value
 from plone.recipe.codeanalysis.clean_lines import CleanLines
 from plone.recipe.codeanalysis.csslint import CSSLint
 from plone.recipe.codeanalysis.debug_statements import DebugStatements
@@ -13,11 +16,11 @@ from plone.recipe.codeanalysis.py_hasattr import HasAttr
 from plone.recipe.codeanalysis.python_utf8_header import UTF8Headers
 from plone.recipe.codeanalysis.quoting import PreferSingleQuotes
 from plone.recipe.codeanalysis.zptlint import ZPTLint
+from time import time
 import os
 import subprocess
 import zc.buildout
 import zc.recipe.egg
-
 
 current_dir = os.path.dirname(__file__)
 all_checks = [
@@ -54,6 +57,7 @@ class Recipe(object):
 
         # Set required default options
         self.options.setdefault('directory', '.')
+        self.options.setdefault('multiprocessing', 'False')
         self.options.setdefault('pre-commit-hook', 'True')
         # Flake 8
         self.options.setdefault('flake8', 'True')
@@ -210,19 +214,35 @@ class Recipe(object):
 
 
 def code_analysis(options):
-    status_codes = []
-    for klass in all_checks:
-        check = klass(options)
+    start = time()
+    multiprocessing = options.get('multiprocessing') == 'True'
+    lock = Lock() if multiprocessing else None
+    status = Value('i', 0)
 
-        if check.enabled and not check.run():
-            status_codes.append(False)
+    def taskrunner(klass, options, lock, status):
+        check = klass(options, lock)
+        if check.enabled:
+            if check.run():
+                status.value += 1
+        else:
+            status.value += 1
+
+    if multiprocessing:
+        procs = [
+            Process(target=taskrunner, args=(klass, options, lock, status))
+            for klass in all_checks
+        ]
+        [p.start() for p in procs]
+        [p.join() for p in procs]
+    else:
+        for klass in all_checks:
+            taskrunner(klass, options, lock, status)
 
     # Check all status codes and return with exit code 1 if one of the code
     # analysis steps did not return True
     if options['return-status-codes'] != 'False':
-        if not all(status_codes):
-            print('The command "bin/code-analysis" exited with 1.')
-            exit(1)
+        exit_code = int(not status.value == len(all_checks))
 
-        print('The command "bin/code-analysis" exited with 0.')
-        exit(0)
+        print('The command "bin/code-analysis" exited with {0:d} in {1:.03f}s.'
+              .format(exit_code, time() - start))
+        exit(exit_code)

--- a/plone/recipe/codeanalysis/analyser.py
+++ b/plone/recipe/codeanalysis/analyser.py
@@ -2,12 +2,11 @@
 from abc import ABCMeta
 from abc import abstractproperty
 from tempfile import TemporaryFile
+from time import time
 import os
 import re
 import subprocess
 import sys
-
-MAX_LINE_LENGTH = 20
 
 
 def is_string(unknown):
@@ -41,6 +40,7 @@ class Analyser:
         """
         self.options = options
         self.lock = lock
+        self.start = time()
 
     @abstractproperty
     def title(self):
@@ -55,9 +55,10 @@ class Analyser:
             self.lock.acquire()
 
         out = self.colors.get(log_type, '[\033[00;31m {0:s} \033[0m]')
-        print('{0:<20s}{1:>10s}'.format(
+        print('{0:.<30}{1:.>25} in {2:.03f}s'.format(
             self.title,
             out.format(log_type.upper()),
+            time() - self.start,
         ))
 
         if msg:
@@ -171,7 +172,7 @@ class Analyser:
         output = map(
             lambda x: error.sub(self.output_replace, x), output.splitlines()
         )
-        return u'\n'.join(output)
+        return u'\n'.join(output).strip()
 
     def parse_output(self, output_file, return_code):
         if return_code:
@@ -207,7 +208,6 @@ class Analyser:
 
         try:
             assert len(self.cmd) > 0  # skip if there's no command
-
             process = subprocess.Popen(self.cmd,
                                        stderr=subprocess.STDOUT,
                                        stdout=output_file)

--- a/plone/recipe/codeanalysis/clean_lines.py
+++ b/plone/recipe/codeanalysis/clean_lines.py
@@ -66,8 +66,6 @@ class CleanLines(Analyser):
         return errors
 
     def run(self):
-        CleanLines.log('title', self.title)
-
         # Should we exclude some files?
         exclude = CleanLines.split_lines(self.get_prefixed_option('exclude'))
         total_errors = []
@@ -93,13 +91,11 @@ class CleanLines(Analyser):
                 total_errors.extend(self.check(file_path, **check))
 
         if total_errors:
-            CleanLines.log('failure')
-            for err in total_errors:
-                print(err)  # noqa
+            self.log('failure', '\n'.join(total_errors))
             return False
-        else:
-            CleanLines.log('ok')
-            return True
+
+        self.log('ok')
+        return True
 
 
 def console_script(options):


### PR DESCRIPTION
Base on #109 i've added multiprocessing features. It's disabled by default because i need somebody to check it on jenkins.plone.org, but i recommend to turn it on by default. This brings 2-4 speed when running on larger packages, specially with JSHint and JSCS. 
Below a small demo on an Core2Duo 4x2.67 GHz.

### current 1.x release

    $ bin/code-analysis
    Flake8.............................[ OK ] in 0.698s
    JSHint.............................[ OK ] in 2.524s
    JSCS...............................[ OK ] in 1.078s
    CSS Lint......................[ FAILURE ] in 0.625s
    /home/demo/workspace/a-large.package/dev/styles/styles.css: line 7, col 1, Error - Rule is empty.
    /home/demo/workspace/a-large.package/dev/styles/styles.css: line 13, col 1, Error - Rule is empty.
    /home/demo/workspace/a-large.package/dev/styles/styles.css: line 15, col 1, Error - Rule is empty.
    ZPT Lint...........................[ OK ] in 0.107s
    Deprecated aliases.................[ OK ] in 0.102s
    Check utf-8 headers................[ OK ] in 0.038s
    Check clean lines..................[ OK ] in 2.960s
    Double quotes......................[ OK ] in 0.040s
    PEP 3101...........................[ OK ] in 0.077s
    Check imports......................[ OK ] in 0.202s
    Debug statements..............[ FAILURE ] in 0.674s
    /home/demo/workspace/a-large.package/dev/express/utils/service-manager.js:83: found console.log
    /home/demo/workspace/a-large.package/dev/util/ModifyNav.js:35: found console.log
    /home/demo/workspace/a-large.package/dev/express/mock-server.js:39: found console.log
    /home/demo/workspace/a-large.package/dev/express/mock-server.js:81: found console.log
    Translations.......................[ OK ] in 0.046s
    The command "bin/code-analysis" exited with 1 in 9.186s.

### new 2.x multiprocessing

    $ bin/code-analysis
    ZPT Lint...........................[ OK ] in 0.219s
    Check utf-8 headers................[ OK ] in 0.060s
    Double quotes......................[ OK ] in 0.051s
    Translations.......................[ OK ] in 0.046s
    PEP 3101...........................[ OK ] in 0.198s
    Deprecated aliases.................[ OK ] in 0.311s
    Check imports......................[ OK ] in 0.470s
    Flake8.............................[ OK ] in 1.828s
    Debug statements..............[ FAILURE ] in 1.722s
    /home/demo/workspace/a-large.package/dev/express/utils/service-manager.js:83: found console.log
    /home/demo/workspace/a-large.package/dev/util/ModifyNav.js:35: found console.log
    /home/demo/workspace/a-large.package/dev/express/mock-server.js:39: found console.log
    /home/demo/workspace/a-large.package/dev/express/mock-server.js:81: found console.log
    CSS Lint......................[ FAILURE ] in 2.173s
    /home/demo/workspace/a-large.package/dev/styles/styles.css: line 7, col 1, Error - Rule is empty.
    /home/demo/workspace/a-large.package/dev/styles/styles.css: line 13, col 1, Error - Rule is empty.
    /home/demo/workspace/a-large.package/dev/styles/styles.css: line 15, col 1, Error - Rule is empty.
    JSCS...............................[ OK ] in 2.582s
    JSHint.............................[ OK ] in 4.317s
    Check clean lines..................[ OK ] in 4.246s
    The command "bin/code-analysis" exited with 1 in 4.452s.

@tisto, @gforcada can you please have a look into this and @do3cc since you did the pre-commit pull?