### PR TITLE
Create hooks folder if it doesn't exist

### DIFF
--- a/plone/recipe/codeanalysis/README.rst
+++ b/plone/recipe/codeanalysis/README.rst
@@ -85,3 +85,16 @@ Then the git pre-commit hook has been installed::
 
     >>> 'install git pre-commit hook.' in buildout_output_lower
     True
+
+If the ``hooks`` directory does not exist is created as well::
+
+    >>> subprocess.call(['rm', '-rf', '.git'])
+    0
+    >>> subprocess.call(['mkdir', '-p', '.git'])
+    0
+    >>> buildout_output_lower = system(buildout).lower()
+    >>> import os
+    >>> os.path.isdir('.git/hooks')
+    True
+    >>> 'install git pre-commit hook.' in buildout_output_lower
+    True

--- a/plone/recipe/codeanalysis/__init__.py
+++ b/plone/recipe/codeanalysis/__init__.py
@@ -192,12 +192,16 @@ class Recipe(object):
             add_script(cmd, arguments=arguments)
 
     def install_pre_commit_hook(self):
-        git_hooks_directory = self.buildout['buildout']['directory'] + \
-            '/.git/hooks'
-        if not os.path.exists(git_hooks_directory):
+        git_directory = self.buildout['buildout']['directory'] + '/.git'
+        if not os.path.exists(git_directory):
             print('Unable to create git pre-commit hook, '
                   'this does not seem to be a git repository.')
             return
+
+        git_hooks_directory = git_directory + '/hooks'
+        if not os.path.exists(git_hooks_directory):
+            os.mkdir(git_hooks_directory)
+
         with open(git_hooks_directory + '/pre-commit', 'w') as output_file:
             output_file.write('#!/bin/bash\nbin/code-analysis')
         subprocess.call([


### PR DESCRIPTION
When trying to install the pre-commit hook,
in some rare scenarios there may be a .git folder but not a hooks
folder within it.

This commit handles this scenario: if there is a .git folder but
no hooks folder within, just create it and continue.

This fixes:
https://github.com/plone/plone.recipe.codeanalysis/issues/124