### PR TITLE
Fix .git/pre-commit hook on NixOS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Change history
 2.1.1 (unreleased)
 ------------------
 
+- Fix issue where commit hook did not work on NixOS
+  (fixed to use ``/usr/bin/env bash`` instead ``/bin/bash``).
+  [datakurre]
+
 - Allow to pass a folder where to run code analysis against.
   [gforcada]
 

--- a/plone/recipe/codeanalysis/__init__.py
+++ b/plone/recipe/codeanalysis/__init__.py
@@ -178,7 +178,7 @@ class Recipe(object):
             os.mkdir(git_hooks_directory)
 
         with open(git_hooks_directory + '/pre-commit', 'w') as output_file:
-            output_file.write('#!/bin/bash\nbin/code-analysis')
+            output_file.write('#!/usr/bin/env bash\nbin/code-analysis')
         subprocess.call([
             'chmod',
             '775',


### PR DESCRIPTION
NixOS does not have /bin/bash, but relies on /usr/bin/env convention.