### PR TITLE
test on python 3.5 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - 2.7
   - 3.4
+  - 3.5
+  - 3.6
 sudo: false
 cache:
   directories:
@@ -15,6 +17,14 @@ env:
 matrix:
   allow_failures:
     - python: 3.4
+      env: CONF=extras.cfg EXTRAS_INSTALLED=true
+    - python: 3.5
+      env: CONF=travis.cfg
+    - python: 3.5
+      env: CONF=extras.cfg EXTRAS_INSTALLED=true
+    - python: 3.6
+      env: CONF=travis.cfg
+    - python: 3.6
       env: CONF=extras.cfg EXTRAS_INSTALLED=true
 install:
   - pip install -r requirements.txt

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,12 @@ Change history
 - Fix code analysis errors.
   [gforcada]
 
+- Fix travis (newer setuptools and zc.buildout needed)
+  [gforcada]
+
+- Check Python 3.5 and 3.6 in travis as well (although they fail currently).
+  [gforcada]
+
 2.2 (2016-02-20)
 ----------------
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -63,8 +63,8 @@ eggs =
 
 [versions]
 # keep them in sync with requirements.txt
-setuptools = 33.1.1
-zc.buildout = 2.8.0
+setuptools = 38.2.4
+zc.buildout = 2.10.0
 
 bleach = 1.4.2
 chardet = 2.3.0
@@ -114,6 +114,7 @@ twine = 1.6.4
 Unidecode = 0.4.18
 wheel = 0.26.0
 z3c.dependencychecker = 1.15
+zdaemon = 4.2.0
 zc.recipe.cmmi = 1.3.6
 zc.recipe.egg = 2.0.3
 zc.recipe.testrunner = 2.0.0
@@ -141,3 +142,7 @@ zope.testing = 4.5.0
 zope.testrunner = 4.0.4
 zope.traversing = 4.0.0
 zptlint = 0.2.4
+zc.recipe.deployment = 1.3.0
+zc.zdaemonrecipe = 1.0.0
+WebOb = 1.7.4
+ZConfig = 3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # keep them in sync with buildout.cfg
-setuptools==33.1.1
-zc.buildout==2.8.0
+setuptools==38.2.4
+zc.buildout==2.10.0
 
 coverage==3.7
 coveralls==1.2.0


### PR DESCRIPTION
I don't like to make pull requests like this, but this is a two in one:
- double checks that yes, there is a problem with newer python versions (3.5 and 3.6, see https://github.com/buildout/buildout/issues/434 for details)
- bump zc.buildout and setuptools to newer versions which fix the pypi API only available through SSL problem