### PR TITLE
Add 'find-untranslated-no-summary' option for i18ndude.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,9 @@ Change history
 - Check Python 3.5 and 3.6 in travis as well (although they fail currently).
   [gforcada]
 
+- Add 'find-untranslated-no-summary' option for i18ndude.
+  [tmassman]
+
 2.2 (2016-02-20)
 ----------------
 

--- a/README.rst
+++ b/README.rst
@@ -430,6 +430,10 @@ system:
     Allows you to specify directories and/or files which you don't want to be
     checked. Default is none.
 
+**find-untranslated-no-summary**
+    The report will contain only the errors for each file.
+    Default is ``False``.
+
 **i18ndude-bin**
     Set the path to a custom version of `i18ndude`_.
     Default is none.

--- a/plone/recipe/codeanalysis/i18ndude.py
+++ b/plone/recipe/codeanalysis/i18ndude.py
@@ -16,9 +16,18 @@ class I18NDude(Analyser):
         if files:
             cmd.append(self.options.get('i18ndude-bin') or '')
             cmd.append('find-untranslated')
+            if self.nosummary:
+                cmd.append('--nosummary')
             cmd.extend(files)
 
         return cmd
+
+    @property
+    def nosummary(self):
+        """The report will contain only the errors for each file."""
+        return I18NDude.normalize_boolean(
+            self.get_prefixed_option('no-summary')
+        )
 
 
 def console_script(options):

--- a/plone/recipe/codeanalysis/i18ndude.py
+++ b/plone/recipe/codeanalysis/i18ndude.py
@@ -26,7 +26,7 @@ class I18NDude(Analyser):
     def nosummary(self):
         """The report will contain only the errors for each file."""
         return I18NDude.normalize_boolean(
-            self.get_prefixed_option('no-summary')
+            self.get_prefixed_option('no-summary'),
         )
 
 

--- a/plone/recipe/codeanalysis/tests/test_i18ndude.py
+++ b/plone/recipe/codeanalysis/tests/test_i18ndude.py
@@ -42,6 +42,22 @@ class TestI18NDude(CodeAnalysisTestCase):
         if os.path.isfile('../../bin/i18ndude'):  # when cwd is parts/test
             self.options['i18ndude-bin'] = '../../bin/i18ndude'
 
+    def test_nosummary_option(self):
+        i18ndude = I18NDude(self.options)
+        self.assertFalse(i18ndude.nosummary)
+        self.options['find-untranslated-no-summary'] = 'True'
+        i18ndude = I18NDude(self.options)
+        self.assertTrue(i18ndude.nosummary)
+
+    @unittest.skipIf(not I18NDUDE_INSTALLED, I18NDUDE_NOT_INSTALLED_MSG)
+    def test_nosummary_cmd(self):
+        self.given_a_file_in_test_dir('invalid.pt', INVALID_CODE)
+        i18ndude = I18NDude(self.options)
+        self.assertNotIn('--nosummary', i18ndude.cmd)
+        self.options['find-untranslated-no-summary'] = 'True'
+        i18ndude = I18NDude(self.options)
+        self.assertIn('--nosummary', i18ndude.cmd)
+
     @unittest.skipIf(not I18NDUDE_INSTALLED, I18NDUDE_NOT_INSTALLED_MSG)
     def test_analysis_should_return_false_when_error_found(self):
         self.given_a_file_in_test_dir('invalid.pt', INVALID_CODE)


### PR DESCRIPTION
For bigger projects with a lot of pt files it's very hard to see the problematic templates if every file, even correct ones, is printed to the command line. This option (default to false, so no change in current installations) enables the ``--no-summary`` mode for ``i18ndude``, which only shows the errors for each file.