### PR TITLE
Post-merge cleanup for #217 replaces autocheckouts with version pins

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,7 +43,7 @@ Change history
   Fixes #67.
   [gyst]
   
-
+- Post-merge cleanup of source dependencies for the python3 work.
 
 2.3 (2018-01-18)
 ----------------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -15,14 +15,8 @@ allow-picked-versions = true
 
 extensions = mr.developer
 auto-checkout =
-   i18ndude
-   importchecker
-   zc.buildout
 
 [sources]
-i18ndude = git https://github.com/gyst/i18ndude.git
-importchecker = git https://github.com/minddistrict/importchecker.git
-zc.buildout = git https://github.com/gyst/buildout.git
 
 
 [dependencychecker]
@@ -132,7 +126,8 @@ flake8-todo = 0.4
 gp.recipe.node = 0.12.7.1
 hexagonit.recipe.download = 1.7.1
 html5lib = 0.9999999
-i18ndude = 4.3
+i18ndude = 5.1
+importchecker = 2.0
 isort = 4.2.0
 lxml = 4.1.1
 manuel = 1.8.0

--- a/plone/recipe/codeanalysis/chameleonlint.py
+++ b/plone/recipe/codeanalysis/chameleonlint.py
@@ -16,10 +16,10 @@ if PY3:
 # inspired by p01.checker:
 #   http://pydoc.net/Python/p01.checker/0.5.6/p01.checker.checker/
 
-DOCTYPE_WRAPPER = '''\
+DOCTYPE_WRAPPER = """\
 <!DOCTYPE html [<!ENTITY nbsp 'no-break space'>
                 <!ENTITY times 'multiplication sign'>]>
-{}'''
+{}"""
 
 
 class ChameleonLint(Analyser):


### PR DESCRIPTION
This is effectively a no-op change. The only code changes are to satisfy the Jenkins codeanalysis, go figure.

Turns out none of these source checkouts are 'hard' dependencies that would bork a release.
And all these dependencies have already been released as eggs by now.