### PR TITLE
z3c.dependencychecker use exit code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Change history
 3.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Newer versions of z3c.dependencychecker already report its exit code.
+  [gforcada]
 
 3.0.1 (2018-06-27)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -481,6 +481,8 @@ Look at `Flake8 documentation`_
 **dependencychecker-bin**
     Set the path to a custom version of ``dependencychecker``.
 
+.. note:: Version 2.3 or bigger must be used so that it reports its exit code correctly.
+
 **importchecker**
     If set to True, import statement analysis is run and unused
     imports are reported. Default is ``False``.

--- a/plone/recipe/codeanalysis/dependencychecker.py
+++ b/plone/recipe/codeanalysis/dependencychecker.py
@@ -13,15 +13,6 @@ class DependencyChecker(Analyser):
         cmd = [self.get_prefixed_option('bin') or '']
         return cmd
 
-    def parse_output(self, output_file, return_code):
-        """dependencychecker always returns 0 even when
-        errors are found. Catch that here.
-        """
-        has_errors = bool(output_file.read())
-        output_file.seek(0)  # reset even though super does so as well
-        return super(DependencyChecker, self).parse_output(
-            output_file, has_errors)
-
 
 def console_script(options):
     console_factory(DependencyChecker, options)


### PR DESCRIPTION
Since version 2.3

There's a ``--exit-zero`` command line switch, but we are probably not interested in using it.

As z3c.dependencychecker is not installed by us, we can only mention it on our docs...